### PR TITLE
EffectComposer: WebXR support

### DIFF
--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -9,6 +9,8 @@ import { ShaderPass } from './ShaderPass.js';
 import { MaskPass } from './MaskPass.js';
 import { ClearMaskPass } from './MaskPass.js';
 
+const size = /* @__PURE__ */ new Vector2();
+
 class EffectComposer {
 
 	constructor( renderer, renderTarget ) {
@@ -19,7 +21,7 @@ class EffectComposer {
 
 		if ( renderTarget === undefined ) {
 
-			const size = renderer.getSize( new Vector2() );
+			renderer.getSize( size );
 			this._width = size.width;
 			this._height = size.height;
 
@@ -47,6 +49,22 @@ class EffectComposer {
 		this.copyPass = new ShaderPass( CopyShader );
 
 		this.clock = new Clock();
+
+		this.onSessionStateChange = this.onSessionStateChange.bind( this );
+		this.renderer.xr.addEventListener( 'sessionstart', this.onSessionStateChange );
+		this.renderer.xr.addEventListener( 'sessionend', this.onSessionStateChange );
+
+	}
+
+	onSessionStateChange() {
+
+		this.renderer.getSize( size );
+		this._width = size.width;
+		this._height = size.height;
+
+		this._pixelRatio = this.renderer.xr.isPresenting ? 1 : this.renderer.getPixelRatio();
+
+		this.setSize( this._width, this._height );
 
 	}
 
@@ -168,7 +186,7 @@ class EffectComposer {
 
 		if ( renderTarget === undefined ) {
 
-			const size = this.renderer.getSize( new Vector2() );
+			this.renderer.getSize( size );
 			this._pixelRatio = this.renderer.getPixelRatio();
 			this._width = size.width;
 			this._height = size.height;
@@ -221,6 +239,9 @@ class EffectComposer {
 		this.renderTarget2.dispose();
 
 		this.copyPass.dispose();
+
+		this.renderer.xr.removeEventListener( 'sessionstart', this.onSessionStateChange );
+		this.renderer.xr.removeEventListener( 'sessionend', this.onSessionStateChange );
 
 	}
 

--- a/examples/jsm/postprocessing/Pass.js
+++ b/examples/jsm/postprocessing/Pass.js
@@ -63,7 +63,13 @@ class FullScreenQuad {
 
 	render( renderer ) {
 
+		// Disable XR projection for fullscreen effects
+		// https://github.com/mrdoob/three.js/pull/18846
+		const xrEnabled = renderer.xr.enabled;
+
+		renderer.xr.enabled = false;
 		renderer.render( this._mesh, _camera );
+		renderer.xr.enabled = xrEnabled;
 
 	}
 


### PR DESCRIPTION
Related issue: #18846, depends on #26160

**Description**

Mirrors the technique in #26160 for blitting to EffectComposer, resizing with the base layer and disabling XR projection for fullscreen effects via `FullScreenQuad` (which is actually a triangle?).

Below was taken with the emulator, but previous fixes ensures it also works on-device.

![image](https://github.com/CodyJasonBennett/three.js/assets/23324155/f735de31-c0f7-4dbc-a108-ce3508d48a42)
